### PR TITLE
105% faster decoding; 7% faster encoding; MSRV lowered to 1.36

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,12 @@
 [package]
 name = "base62"
 version = "2.0.0"
-authors = ["Francois Bernier <frankbernier@gmail.com>", "Chai T. Rex <ChaiTRex@users.noreply.github.com>"]
+authors = [
+    "François Bernier <frankbernier@gmail.com>",
+    "Chai T. Rex <ChaiTRex@users.noreply.github.com>",
+    "Kevin Darlington <kevin@outroot.com>",
+    "Christopher Tarquini <code@tarq.io>",
+]
 edition = "2018"
 description = "A Base62 encoding/decoding library"
 documentation = "https://docs.rs/base62/"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,9 @@ exclude = [
 ]
 
 [dev-dependencies]
-quickcheck = "1"
 criterion = "0.3.5"
+quickcheck = "1"
+rand = "0.8.5"
 
 [[bench]]
 name = "base62"

--- a/benches/base62.rs
+++ b/benches/base62.rs
@@ -1,31 +1,76 @@
 use base62::{
-    decode, decode_alternative, encode, encode_alternative, encode_alternative_buf, encode_buf,
+    decode, decode_alternative, /*digit_count,*/ encode, encode_alternative,
+    encode_alternative_buf, encode_buf,
 };
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use rand::distributions::Standard;
+use rand::{thread_rng, Rng};
 
 pub fn criterion_benchmark(c: &mut Criterion) {
+    let mut random_u128s = thread_rng().sample_iter::<u128, Standard>(Standard);
+
+    c.bench_function("decode_standard", |b| {
+        b.iter(|| decode(black_box("7n42DGM5Tflk9n8mt7Fhc7")))
+    });
+
+    c.bench_function("decode_standard_random", |b| {
+        b.iter(|| decode(black_box(encode(random_u128s.next().unwrap()))))
+    });
+
+    c.bench_function("decode_alternative", |b| {
+        b.iter(|| decode_alternative(black_box("7N42dgm5tFLK9N8MT7fHC7")))
+    });
+
+    c.bench_function("decode_alternative_random", |b| {
+        b.iter(|| decode_alternative(black_box(encode_alternative(random_u128s.next().unwrap()))))
+    });
+
+    /*
+    c.bench_function("digit_count", |b| {
+        b.iter(|| digit_count(black_box(random_u128s.next().unwrap())))
+    });
+    */
+
     c.bench_function("encode_standard_new", |b| {
         b.iter(|| encode(black_box(u128::MAX)))
+    });
+
+    c.bench_function("encode_standard_new_random", |b| {
+        b.iter(|| encode(black_box(random_u128s.next().unwrap())))
     });
 
     c.bench_function("encode_standard_buf", |b| {
         b.iter(|| encode_buf(black_box(u128::MAX), black_box(&mut String::new())))
     });
 
+    c.bench_function("encode_standard_buf_random", |b| {
+        b.iter(|| {
+            encode_buf(
+                black_box(random_u128s.next().unwrap()),
+                black_box(&mut String::new()),
+            )
+        })
+    });
+
     c.bench_function("encode_alternative_new", |b| {
         b.iter(|| encode_alternative(black_box(u128::MAX)))
+    });
+
+    c.bench_function("encode_alternative_new_random", |b| {
+        b.iter(|| encode_alternative(black_box(random_u128s.next().unwrap())))
     });
 
     c.bench_function("encode_alternative_buf", |b| {
         b.iter(|| encode_alternative_buf(black_box(u128::MAX), black_box(&mut String::new())))
     });
 
-    c.bench_function("decode_standard", |b| {
-        b.iter(|| decode(black_box("7n42DGM5Tflk9n8mt7Fhc7")))
-    });
-
-    c.bench_function("decode_alternative", |b| {
-        b.iter(|| decode_alternative(black_box("7N42dgm5tFLK9N8MT7fHC7")))
+    c.bench_function("encode_alternative_buf_random", |b| {
+        b.iter(|| {
+            encode_alternative_buf(
+                black_box(random_u128s.next().unwrap()),
+                black_box(&mut String::new()),
+            )
+        })
     });
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -330,7 +330,7 @@ macro_rules! internal_decoder_loop_body {
 
         let char_value = *unsafe { CHARACTER_VALUES.get_unchecked($ch as usize) };
         if char_value == 255 {
-            return Result::Err(DecodeError::InvalidBase62Byte($ch, $i));
+            return Err(DecodeError::InvalidBase62Byte($ch, $i));
         }
         $result = $result.wrapping_mul(BASE).wrapping_add(char_value as u64);
     };
@@ -340,7 +340,7 @@ macro_rules! internal_decoder_fn {
     ($fn_name:ident, $numeric_start_value:expr, $uppercase_start_value:expr, $lowercase_start_value:expr) => {
         fn $fn_name(mut input: &[u8]) -> Result<u128, DecodeError> {
             if input.is_empty() {
-                return Result::Err(DecodeError::EmptyInput);
+                return Err(DecodeError::EmptyInput);
             }
 
             // Remove leading zeroes
@@ -425,17 +425,15 @@ macro_rules! internal_decoder_fn {
                 let result = result_a
                     .checked_add(result_b.wrapping_add(result_c))
                     .ok_or(DecodeError::ArithmeticOverflow)?;
-                Result::Ok(result)
+                Ok(result)
             } else {
-                Result::Err(
-                    input
-                        .iter()
-                        .position(|b| !b.is_ascii_alphanumeric())
-                        .map(|i| {
-                            DecodeError::InvalidBase62Byte(input[i], chopped_count.wrapping_add(i))
-                        })
-                        .unwrap_or(DecodeError::ArithmeticOverflow),
-                )
+                Err(input
+                    .iter()
+                    .position(|b| !b.is_ascii_alphanumeric())
+                    .map(|i| {
+                        DecodeError::InvalidBase62Byte(input[i], chopped_count.wrapping_add(i))
+                    })
+                    .unwrap_or(DecodeError::ArithmeticOverflow))
             }
         }
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,33 +13,41 @@ use alloc::string::String;
 
 const BASE: u64 = 62;
 const BASE_TO_2: u64 = BASE * BASE;
-const BASE_TO_3: u64 = BASE_TO_2 * BASE;
-const BASE_TO_6: u64 = BASE_TO_3 * BASE_TO_3;
-const BASE_TO_10: u128 = BASE_TO_6 as u128 * BASE_TO_2 as u128 * BASE_TO_2 as u128;
+const BASE_TO_3: u64 = BASE * BASE * BASE;
+const BASE_TO_6: u64 = BASE * BASE * BASE * BASE * BASE * BASE;
+const BASE_TO_10: u128 = (BASE_TO_6 * BASE * BASE * BASE * BASE) as u128;
 const BASE_TO_11: u128 = BASE_TO_10 * BASE as u128;
 
-const BASE_POWERS: [(u128, u128); 22] = {
-    let mut result: [(u128, u128); 22] = [(1, 1); 22];
-
-    let mut a = 1;
-    let mut b = 1;
-
-    let mut i = 10;
-    while i < 20 {
-        a *= 62;
-        result[i] = (a, b);
-        i += 1;
-    }
-
-    while i < 22 {
-        a *= 62;
-        b *= 62;
-        result[i] = (a, b);
-        i += 1;
-    }
-
-    result
-};
+const BASE_POWERS: [(u128, u128); 22] = [
+    (1, 1),
+    (1, 1),
+    (1, 1),
+    (1, 1),
+    (1, 1),
+    (1, 1),
+    (1, 1),
+    (1, 1),
+    (1, 1),
+    (1, 1),
+    (BASE as u128, 1),
+    ((BASE * BASE) as u128, 1),
+    ((BASE * BASE * BASE) as u128, 1),
+    ((BASE * BASE * BASE * BASE) as u128, 1),
+    ((BASE * BASE * BASE * BASE * BASE) as u128, 1),
+    ((BASE * BASE * BASE * BASE * BASE * BASE) as u128, 1),
+    ((BASE * BASE * BASE * BASE * BASE * BASE * BASE) as u128, 1),
+    (
+        (BASE * BASE * BASE * BASE * BASE * BASE * BASE * BASE) as u128,
+        1,
+    ),
+    (
+        (BASE * BASE * BASE * BASE * BASE * BASE * BASE * BASE * BASE) as u128,
+        1,
+    ),
+    (BASE_TO_10, 1),
+    (BASE_TO_10 * BASE as u128, BASE as u128),
+    (BASE_TO_10 * (BASE * BASE) as u128, (BASE * BASE) as u128),
+];
 
 /// Indicates the cause of a decoding failure in [`decode`](crate::decode) or
 /// [`decode_alternative`](crate::decode_alternative).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,9 +150,10 @@ macro_rules! internal_decoder_fn {
             }
             let result_c = result_c as u128;
 
-            Ok(result_a
+            let result = result_a
                 .checked_add(result_b.wrapping_add(result_c))
-                .ok_or(DecodeError::ArithmeticOverflow)?)
+                .ok_or(DecodeError::ArithmeticOverflow)?;
+            Ok(result)
         }
     };
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,8 @@ const BASE_TO_6: u64 = BASE_TO_3 * BASE_TO_3;
 const BASE_TO_10: u128 = (BASE_TO_6 * BASE_TO_3 * BASE) as u128;
 const BASE_TO_11: u128 = BASE_TO_10 * BASE as u128;
 
-const BASE_POWERS: [(u128, u128); 22] = [
+const BASE_POWERS: [(u128, u128); 23] = [
+    (0, 0),
     (1, 1),
     (1, 1),
     (1, 1),
@@ -126,9 +127,9 @@ macro_rules! internal_decoder_fn {
                 input = &input[1..];
                 chopped_count += 1;
             }
-            if input.len() <= 22 {
-                let &(a_power, b_power) =
-                    unsafe { BASE_POWERS.get_unchecked(input.len().wrapping_sub(1)) };
+            let input_len = input.len();
+            if input_len <= 22 {
+                let (a_power, b_power) = BASE_POWERS[input_len];
 
                 let mut iter = (chopped_count..).zip(input.iter().map(|&ch| ch));
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,15 @@ const BASE_TO_9: u64 = BASE_TO_8 * BASE;
 const BASE_TO_10: u128 = (BASE_TO_9 * BASE) as u128;
 const BASE_TO_11: u128 = BASE_TO_10 * BASE as u128;
 const BASE_TO_12: u128 = BASE_TO_11 * BASE as u128;
+const BASE_TO_13: u128 = BASE_TO_12 * BASE as u128;
+const BASE_TO_14: u128 = BASE_TO_13 * BASE as u128;
+const BASE_TO_15: u128 = BASE_TO_14 * BASE as u128;
+const BASE_TO_16: u128 = BASE_TO_15 * BASE as u128;
+const BASE_TO_17: u128 = BASE_TO_16 * BASE as u128;
+const BASE_TO_18: u128 = BASE_TO_17 * BASE as u128;
+const BASE_TO_19: u128 = BASE_TO_18 * BASE as u128;
+const BASE_TO_20: u128 = BASE_TO_19 * BASE as u128;
+const BASE_TO_21: u128 = BASE_TO_20 * BASE as u128;
 
 /// Indicates the cause of a decoding failure in [`decode`](crate::decode) or
 /// [`decode_alternative`](crate::decode_alternative).
@@ -60,46 +69,270 @@ impl core::fmt::Display for DecodeError {
 
 macro_rules! internal_decoder_loop_body {
     ($result:ident, $ch:ident, $i:ident, $numeric_start_value:expr, $uppercase_start_value:expr, $lowercase_start_value:expr) => {
-        let mut ch: u8 = $ch;
+        const CHARACTER_VALUES: [u8; 256] = [
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            $numeric_start_value + 0,
+            $numeric_start_value + 1,
+            $numeric_start_value + 2,
+            $numeric_start_value + 3,
+            $numeric_start_value + 4,
+            $numeric_start_value + 5,
+            $numeric_start_value + 6,
+            $numeric_start_value + 7,
+            $numeric_start_value + 8,
+            $numeric_start_value + 9,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            $uppercase_start_value + 0,
+            $uppercase_start_value + 1,
+            $uppercase_start_value + 2,
+            $uppercase_start_value + 3,
+            $uppercase_start_value + 4,
+            $uppercase_start_value + 5,
+            $uppercase_start_value + 6,
+            $uppercase_start_value + 7,
+            $uppercase_start_value + 8,
+            $uppercase_start_value + 9,
+            $uppercase_start_value + 10,
+            $uppercase_start_value + 11,
+            $uppercase_start_value + 12,
+            $uppercase_start_value + 13,
+            $uppercase_start_value + 14,
+            $uppercase_start_value + 15,
+            $uppercase_start_value + 16,
+            $uppercase_start_value + 17,
+            $uppercase_start_value + 18,
+            $uppercase_start_value + 19,
+            $uppercase_start_value + 20,
+            $uppercase_start_value + 21,
+            $uppercase_start_value + 22,
+            $uppercase_start_value + 23,
+            $uppercase_start_value + 24,
+            $uppercase_start_value + 25,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            $lowercase_start_value + 0,
+            $lowercase_start_value + 1,
+            $lowercase_start_value + 2,
+            $lowercase_start_value + 3,
+            $lowercase_start_value + 4,
+            $lowercase_start_value + 5,
+            $lowercase_start_value + 6,
+            $lowercase_start_value + 7,
+            $lowercase_start_value + 8,
+            $lowercase_start_value + 9,
+            $lowercase_start_value + 10,
+            $lowercase_start_value + 11,
+            $lowercase_start_value + 12,
+            $lowercase_start_value + 13,
+            $lowercase_start_value + 14,
+            $lowercase_start_value + 15,
+            $lowercase_start_value + 16,
+            $lowercase_start_value + 17,
+            $lowercase_start_value + 18,
+            $lowercase_start_value + 19,
+            $lowercase_start_value + 20,
+            $lowercase_start_value + 21,
+            $lowercase_start_value + 22,
+            $lowercase_start_value + 23,
+            $lowercase_start_value + 24,
+            $lowercase_start_value + 25,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+        ];
 
-        // The 32-character block number is which of the following blocks `$ch` starts
-        // in:
-        //     0: characters 0..=31        4: characters 128..=159
-        //     1: characters 32..=63       5: characters 160..=191
-        //     2: characters 64..=95       6: characters 192..=223
-        //     3: characters 96..=127      7: characters 224..=255
-        let block_number = (ch >> 5) as usize;
-
-        // The first valid base 62 character in each block
-        const BLOCK_START_CHARACTERS: [u8; 8] = [0, b'0', b'A', b'a', 0, 0, 0, 0];
-        // Subtract to make the first valid base 62 character in this block zero
-        ch = ch.wrapping_sub(BLOCK_START_CHARACTERS[block_number]);
-
-        // The count of valid base 62 characters in each block
-        const BLOCK_CHARACTER_COUNTS: [u8; 8] = [0, 10, 26, 26, 0, 0, 0, 0];
-        // Valid base 62 characters will now be in
-        // `0..BLOCK_CHARACTER_COUNTS[block_number]`, so return an error if this
-        // character isn't in that range
-        if ch >= BLOCK_CHARACTER_COUNTS[block_number] {
+        let char_value = *unsafe { CHARACTER_VALUES.get_unchecked($ch as usize) };
+        if char_value == 255 {
             return Result::Err(DecodeError::InvalidBase62Byte($ch, $i));
         }
-
-        // The base 62 value of the first valid base 62 character in each block
-        const BLOCK_START_VALUES: [u8; 8] = [
-            0,
-            $numeric_start_value,
-            $uppercase_start_value,
-            $lowercase_start_value,
-            0,
-            0,
-            0,
-            0,
-        ];
-        // Add the base 62 value of the first valid base 62 character in this block to
-        // get the actual base 62 value of this character
-        ch = ch.wrapping_add(BLOCK_START_VALUES[block_number]);
-
-        $result = $result.wrapping_mul(BASE).wrapping_add(ch as u64);
+        $result = $result.wrapping_mul(BASE).wrapping_add(char_value as u64);
     };
 }
 
@@ -251,33 +484,36 @@ pub fn decode_alternative<T: AsRef<[u8]>>(input: T) -> Result<u128, DecodeError>
 }
 
 // Finds out how many base62 digits a value encodes into.
-pub(crate) fn digit_count(mut n: u128) -> usize {
-    let mut result = 1;
+pub(crate) fn digit_count(n: u128) -> usize {
+    const POWERS: [u128; 22] = [
+        0,
+        BASE as u128,
+        BASE_TO_2 as u128,
+        BASE_TO_3 as u128,
+        BASE_TO_4 as u128,
+        BASE_TO_5 as u128,
+        BASE_TO_6 as u128,
+        BASE_TO_7 as u128,
+        BASE_TO_8 as u128,
+        BASE_TO_9 as u128,
+        BASE_TO_10,
+        BASE_TO_11,
+        BASE_TO_12,
+        BASE_TO_13,
+        BASE_TO_14,
+        BASE_TO_15,
+        BASE_TO_16,
+        BASE_TO_17,
+        BASE_TO_18,
+        BASE_TO_19,
+        BASE_TO_20,
+        BASE_TO_21,
+    ];
 
-    if n >= BASE_TO_11 {
-        result += 11;
-        n /= BASE_TO_11;
+    match POWERS.binary_search(&n) {
+        Ok(n) => n.wrapping_add(1),
+        Err(n) => n,
     }
-    if n >= BASE_TO_10 {
-        return result + 10;
-    }
-    let mut n = n as u64;
-    if n >= BASE_TO_6 {
-        result += 6;
-        n /= BASE_TO_6;
-    }
-    if n >= BASE_TO_3 {
-        result += 3;
-        n /= BASE_TO_3;
-    }
-    if n >= BASE_TO_2 {
-        return result + 2;
-    }
-    if n >= BASE {
-        return result + 1;
-    }
-
-    result
 }
 
 macro_rules! internal_encoder_fn {
@@ -287,10 +523,6 @@ macro_rules! internal_encoder_fn {
         /// With this function, `buf` MUST ALREADY have its capacity extended
         /// to hold all the new base62 characters that will be added
         unsafe fn $fn_name(mut num: u128, digits: usize, buf: &mut String) {
-            const NUMERIC_OFFSET: u8 = $numeric_offset;
-            const FIRST_LETTERS_OFFSET: u8 = $first_letters_offset - 10;
-            const LAST_LETTERS_OFFSET: u8 = $last_letters_offset - 10 - 26;
-
             let buf_vec = buf.as_mut_vec();
             let new_len = buf_vec.len().wrapping_add(digits);
             let mut ptr = buf_vec.as_mut_ptr().add(new_len).sub(1);
@@ -299,14 +531,74 @@ macro_rules! internal_encoder_fn {
             let mut u64_num = (num % BASE_TO_10) as u64;
             num /= BASE_TO_10;
             loop {
-                core::ptr::write(ptr, {
-                    let digit = (u64_num % BASE) as u8;
-                    match digit {
-                        0..=9 => digit.wrapping_add(NUMERIC_OFFSET),
-                        10..=35 => digit.wrapping_add(FIRST_LETTERS_OFFSET),
-                        _ => digit.wrapping_add(LAST_LETTERS_OFFSET),
-                    }
-                });
+                const VALUE_CHARACTERS: [u8; 62] = [
+                    $numeric_offset,
+                    $numeric_offset + 1,
+                    $numeric_offset + 2,
+                    $numeric_offset + 3,
+                    $numeric_offset + 4,
+                    $numeric_offset + 5,
+                    $numeric_offset + 6,
+                    $numeric_offset + 7,
+                    $numeric_offset + 8,
+                    $numeric_offset + 9,
+                    $first_letters_offset,
+                    $first_letters_offset + 1,
+                    $first_letters_offset + 2,
+                    $first_letters_offset + 3,
+                    $first_letters_offset + 4,
+                    $first_letters_offset + 5,
+                    $first_letters_offset + 6,
+                    $first_letters_offset + 7,
+                    $first_letters_offset + 8,
+                    $first_letters_offset + 9,
+                    $first_letters_offset + 10,
+                    $first_letters_offset + 11,
+                    $first_letters_offset + 12,
+                    $first_letters_offset + 13,
+                    $first_letters_offset + 14,
+                    $first_letters_offset + 15,
+                    $first_letters_offset + 16,
+                    $first_letters_offset + 17,
+                    $first_letters_offset + 18,
+                    $first_letters_offset + 19,
+                    $first_letters_offset + 20,
+                    $first_letters_offset + 21,
+                    $first_letters_offset + 22,
+                    $first_letters_offset + 23,
+                    $first_letters_offset + 24,
+                    $first_letters_offset + 25,
+                    $last_letters_offset,
+                    $last_letters_offset + 1,
+                    $last_letters_offset + 2,
+                    $last_letters_offset + 3,
+                    $last_letters_offset + 4,
+                    $last_letters_offset + 5,
+                    $last_letters_offset + 6,
+                    $last_letters_offset + 7,
+                    $last_letters_offset + 8,
+                    $last_letters_offset + 9,
+                    $last_letters_offset + 10,
+                    $last_letters_offset + 11,
+                    $last_letters_offset + 12,
+                    $last_letters_offset + 13,
+                    $last_letters_offset + 14,
+                    $last_letters_offset + 15,
+                    $last_letters_offset + 16,
+                    $last_letters_offset + 17,
+                    $last_letters_offset + 18,
+                    $last_letters_offset + 19,
+                    $last_letters_offset + 20,
+                    $last_letters_offset + 21,
+                    $last_letters_offset + 22,
+                    $last_letters_offset + 23,
+                    $last_letters_offset + 24,
+                    $last_letters_offset + 25,
+                ];
+                core::ptr::write(
+                    ptr,
+                    *VALUE_CHARACTERS.get_unchecked((u64_num % BASE) as usize),
+                );
                 ptr = ptr.sub(1);
 
                 digit_index = digit_index.wrapping_add(1);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -794,15 +794,36 @@ mod tests {
 
     #[test]
     fn test_decode_invalid_char() {
-        assert_eq!(
-            decode("00!00000000000000000000000"),
-            Err(DecodeError::InvalidBase62Byte(b'!', 2))
-        );
-        assert_eq!(decode("00!"), Err(DecodeError::InvalidBase62Byte(b'!', 2)));
-        assert_eq!(
-            decode("ds{Z455f"),
-            Err(DecodeError::InvalidBase62Byte(b'{', 2))
-        );
+        let mut input = Vec::with_capacity(40);
+        let mut invalid_chars = (0..b'0')
+            .chain(b'0' + 10..b'A')
+            .chain(b'A' + 26..b'a')
+            .chain(b'a' + 26..=255)
+            .cycle();
+
+        for size in [10, 22, 23, 40].iter().map(|&size| size) {
+            input.clear();
+            for _ in 0..size {
+                input.push(b'0');
+            }
+
+            for i in 0..size {
+                input[i] = b'1';
+                for j in 0..size {
+                    let invalid_char = invalid_chars.next().unwrap();
+                    input[j] = invalid_char;
+
+                    assert_eq!(
+                        decode(&input),
+                        Err(DecodeError::InvalidBase62Byte(invalid_char, j))
+                    );
+
+                    input[j] = b'0';
+                    input[i] = b'1';
+                }
+                input[i] = b'0';
+            }
+        }
     }
 
     #[test]
@@ -859,19 +880,37 @@ mod tests {
     }
 
     #[test]
-    fn test_decode_alternative_invalid_char() {
-        assert_eq!(
-            decode_alternative("00!00000000000000000000000"),
-            Err(DecodeError::InvalidBase62Byte(b'!', 2))
-        );
-        assert_eq!(
-            decode_alternative("00!"),
-            Err(DecodeError::InvalidBase62Byte(b'!', 2))
-        );
-        assert_eq!(
-            decode_alternative("ds{Z455f"),
-            Err(DecodeError::InvalidBase62Byte(b'{', 2))
-        );
+    fn test_decode_altenative_invalid_char() {
+        let mut input = Vec::with_capacity(40);
+        let mut invalid_chars = (0..b'0')
+            .chain(b'0' + 10..b'A')
+            .chain(b'A' + 26..b'a')
+            .chain(b'a' + 26..=255)
+            .cycle();
+
+        for size in [10, 22, 23, 40].iter().map(|&size| size) {
+            input.clear();
+            for _ in 0..size {
+                input.push(b'0');
+            }
+
+            for i in 0..size {
+                input[i] = b'1';
+                for j in 0..size {
+                    let invalid_char = invalid_chars.next().unwrap();
+                    input[j] = invalid_char;
+
+                    assert_eq!(
+                        decode_alternative(&input),
+                        Err(DecodeError::InvalidBase62Byte(invalid_char, j))
+                    );
+
+                    input[j] = b'0';
+                    input[i] = b'1';
+                }
+                input[i] = b'0';
+            }
+        }
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,7 +121,7 @@ macro_rules! internal_decoder_fn {
             }
 
             // Remove leading zeroes
-            while let Option::Some(b'0') = input.get(0) {
+            while let Option::Some(b'0') = input.first() {
                 input = &input[1..];
             }
             match input.len() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,29 @@ const BASE_TO_6: u64 = BASE_TO_3 * BASE_TO_3;
 const BASE_TO_10: u128 = BASE_TO_6 as u128 * BASE_TO_2 as u128 * BASE_TO_2 as u128;
 const BASE_TO_11: u128 = BASE_TO_10 * BASE as u128;
 
+const BASE_POWERS: [(u128, u128); 22] = {
+    let mut result: [(u128, u128); 22] = [(1, 1); 22];
+
+    let mut a = 1;
+    let mut b = 1;
+
+    let mut i = 10;
+    while i < 20 {
+        a *= 62;
+        result[i] = (a, b);
+        i += 1;
+    }
+
+    while i < 22 {
+        a *= 62;
+        b *= 62;
+        result[i] = (a, b);
+        i += 1;
+    }
+
+    result
+};
+
 /// Indicates the cause of a decoding failure in [`decode`](crate::decode) or
 /// [`decode_alternative`](crate::decode_alternative).
 #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
@@ -53,7 +76,7 @@ impl core::fmt::Display for DecodeError {
 }
 
 macro_rules! internal_decoder_loop_body {
-    ($block_start_values:expr, $uint:ty, $result:ident, $ch:ident, $i:ident) => {
+    ($block_start_values:expr, $result:ident, $ch:ident, $i:ident) => {
         let mut ch: u8 = $ch;
 
         // The 32-character block number is which of the following blocks `$ch` starts
@@ -84,10 +107,7 @@ macro_rules! internal_decoder_loop_body {
         // get the actual base 62 value of this character
         ch = ch.wrapping_add(BLOCK_START_VALUES[block_number]);
 
-        $result = $result
-            .checked_mul(BASE as $uint)
-            .and_then(|x| x.checked_add(ch as $uint))
-            .ok_or(DecodeError::ArithmeticOverflow)?;
+        $result = $result.wrapping_mul(BASE).wrapping_add(ch as u64);
     };
 }
 
@@ -98,17 +118,33 @@ macro_rules! internal_decoder_fn {
                 return Result::Err(DecodeError::EmptyInput);
             }
 
-            let mut result = 0_u64;
-            let mut iter = input.iter().map(|&ch| ch).enumerate();
-            for (i, ch) in iter.by_ref().take(10) {
-                internal_decoder_loop_body!($block_start_values, u64, result, ch, i);
-            }
+            let &(a_power, b_power) = unsafe { BASE_POWERS.get_unchecked(input.len() - 1) };
 
-            let mut result = result as u128;
-            for (i, ch) in iter {
-                internal_decoder_loop_body!($block_start_values, u128, result, ch, i);
+            let mut iter = input.iter().map(|&ch| ch).enumerate();
+
+            let mut result_a = 0_u64;
+            for (i, ch) in iter.by_ref().take(10) {
+                internal_decoder_loop_body!($block_start_values, result_a, ch, i);
             }
-            Ok(result)
+            let result_a = (result_a as u128)
+                .checked_mul(a_power)
+                .ok_or(DecodeError::ArithmeticOverflow)?;
+
+            let mut result_b = 0_u64;
+            for (i, ch) in iter.by_ref().take(10) {
+                internal_decoder_loop_body!($block_start_values, result_b, ch, i);
+            }
+            let result_b = (result_b as u128).wrapping_mul(b_power);
+
+            let mut result_c = 0_u64;
+            for (i, ch) in iter {
+                internal_decoder_loop_body!($block_start_values, result_c, ch, i);
+            }
+            let result_c = result_c as u128;
+
+            Ok(result_a
+                .checked_add(result_b.wrapping_add(result_c))
+                .ok_or(DecodeError::ArithmeticOverflow)?)
         }
     };
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ encoding to and decoding from [base62](https://en.wikipedia.org/wiki/Base62).
 [![Docs](https://docs.rs/base62/badge.svg)](https://docs.rs/base62)
 */
 
-//#![no_std]
+#![no_std]
 extern crate alloc;
 use alloc::string::String;
 


### PR DESCRIPTION
* Used lookup tables to greatly speed up decoding and to slightly speed up encoding
* Delayed using `u128`s in decoding the most I could
* Added test cases with randomized inputs
* Added many more invalid byte test cases
* The encoding macro's arguments are easier to understand
* Minimum Supported Rust Version lowered to 1.36
* Added other authors