### PR TITLE
 Add `encode_bytes` and `encode_alternative_bytes` functions to write the result to a byte slice

### DIFF
--- a/benches/base62.rs
+++ b/benches/base62.rs
@@ -1,6 +1,6 @@
 use base62::{
     decode, decode_alternative, /*digit_count,*/ encode, encode_alternative,
-    encode_alternative_buf, encode_buf,
+    encode_alternative_buf, encode_alternative_bytes, encode_buf, encode_bytes,
 };
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use rand::distributions::Standard;
@@ -39,6 +39,16 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         b.iter(|| encode(black_box(random_u128s.next().unwrap())))
     });
 
+    c.bench_function("encode_standard_bytes", |b| {
+        let mut buf = [0; 22];
+        b.iter(|| encode_bytes(black_box(u128::MAX), black_box(&mut buf)))
+    });
+
+    c.bench_function("encode_standard_bytes_random", |b| {
+        let mut buf = [0; 22];
+        b.iter(|| encode_bytes(black_box(random_u128s.next().unwrap()), black_box(&mut buf)))
+    });
+
     c.bench_function("encode_standard_buf", |b| {
         b.iter(|| encode_buf(black_box(u128::MAX), black_box(&mut String::new())))
     });
@@ -58,6 +68,18 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
     c.bench_function("encode_alternative_new_random", |b| {
         b.iter(|| encode_alternative(black_box(random_u128s.next().unwrap())))
+    });
+
+    c.bench_function("encode_alternative_bytes", |b| {
+        let mut buf = [0; 22];
+        b.iter(|| encode_alternative_bytes(black_box(u128::MAX), black_box(&mut buf)))
+    });
+
+    c.bench_function("encode_alternative_bytes_random", |b| {
+        let mut buf = [0; 22];
+        b.iter(|| {
+            encode_alternative_bytes(black_box(random_u128s.next().unwrap()), black_box(&mut buf))
+        })
     });
 
     c.bench_function("encode_alternative_buf", |b| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ encoding to and decoding from [base62](https://en.wikipedia.org/wiki/Base62).
 
 #![no_std]
 extern crate alloc;
-use alloc::{slice, string::String};
+use alloc::string::String;
 
 const BASE: u64 = 62;
 const BASE_TO_2: u64 = BASE * BASE;
@@ -720,11 +720,9 @@ pub fn encode_bytes<T: Into<u128>>(num: T, buf: &mut [u8]) -> Result<usize, Enco
         return Err(EncodeError::BufferTooSmall);
     }
 
-    let buf = &mut buf[..digits];
+    //let buf = &mut buf[..digits];
     unsafe {
-        let new_len = _encode_buf(num, digits, buf, WriteMode::Overwrite);
-        let slice = slice::from_raw_parts_mut(buf.as_mut_ptr(), new_len);
-        buf.swap_with_slice(&mut slice[..new_len]);
+        _encode_buf(num, digits, buf, WriteMode::Overwrite);
     }
 
     Ok(digits)
@@ -763,9 +761,7 @@ pub fn encode_alternative_bytes<T: Into<u128>>(
 
     let buf = &mut buf[..digits];
     unsafe {
-        let new_len = _encode_alternative_buf(num, digits, buf, WriteMode::Overwrite);
-        let slice = slice::from_raw_parts_mut(buf.as_mut_ptr(), new_len);
-        buf.swap_with_slice(&mut slice[..new_len]);
+        _encode_alternative_buf(num, digits, buf, WriteMode::Overwrite);
     }
 
     Ok(digits)


### PR DESCRIPTION
Fixes #6

This PR adds `encode_bytes` and `encode_alternative_bytes` low-level functions for specific zero-allocation use cases.

To achieve this, I changed the `internal_encoder_fn` to operate on a byte slice instead of a String. I moved the final change of the buf `len` outside to the call site and added a parameter to either overwrite or append to the buf.

I only have one question that remains: Should we write zeros to the end of the byte slice we're being passed if it's larger than the result, or should we let the library user handle it themselves using the bytes written len they can get from the `Result` ?

edit: @phayes makes a good point that this is a rather low-level API and since we return the len of the written bytes, the caller can then choose to zero the rest of the buffer themselves or not. I'm going to add a doc comment to specify this.