### PR TITLE
Add `Display` and `DisplayAlternative` wrapper types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,7 +172,7 @@ pub fn encode_alternative_fmt<T: Into<u128>, W: fmt::Write + ?Sized>(
 #[repr(transparent)]
 pub struct DisplayAlternative<T>(pub T);
 
-impl<T: Clone + Into<u128>> fmt::Display for Display<T> {
+impl<T: Clone + Into<u128>> fmt::Display for DisplayAlternative<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         encode_alternative_fmt(self.0.clone(), f)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,16 +124,24 @@ pub fn encode_fmt<T: Into<u128>, W: fmt::Write + ?Sized>(num: T, f: &mut W) -> f
     }
 }
 
-/// Transparent wrapper over a value, [`Display`]ing it via [`encode_fmt()`].
+/// Wraps a number to [`Display`] it via [`encode_fmt()`].
+///
+/// # Example
+/// ```rust
+/// assert_eq!(format!("{}", base62::fmt(1337_u32)), "LZ");
+/// assert_eq!(base62::fmt(1337_u32).to_string(), "LZ");
+/// ```
 ///
 /// [`Display`]: fmt::Display
-#[derive(Copy, Clone, Debug)]
-#[repr(transparent)]
-pub struct Display<T>(pub T);
+pub fn fmt<T: Into<u128>>(num: T) -> impl fmt::Display {
+    Fmt(num.into())
+}
 
-impl<T: Clone + Into<u128>> fmt::Display for Display<T> {
+struct Fmt(u128);
+
+impl fmt::Display for Fmt {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        encode_fmt(self.0.clone(), f)
+        encode_fmt(self.0, f)
     }
 }
 
@@ -165,16 +173,24 @@ pub fn encode_alternative_fmt<T: Into<u128>, W: fmt::Write + ?Sized>(
     }
 }
 
-/// Transparent wrapper over a value, [`Display`]ing it via [`encode_alternative_fmt()`].
+/// Wraps a number to [`Display`] it via [`encode_alternative_fmt()`].
+///
+/// # Example
+/// ```rust
+/// assert_eq!(format!("{}", base62::fmt_alt(1337_u32)), "lz");
+/// assert_eq!(base62::fmt_alt(1337_u32).to_string(), "lz");
+/// ```
 ///
 /// [`Display`]: fmt::Display
-#[derive(Copy, Clone, Debug)]
-#[repr(transparent)]
-pub struct DisplayAlternative<T>(pub T);
+pub fn fmt_alt<T: Into<u128>>(num: T) -> impl fmt::Display {
+    FmtAlternative(num.into())
+}
 
-impl<T: Clone + Into<u128>> fmt::Display for DisplayAlternative<T> {
+struct FmtAlternative(u128);
+
+impl fmt::Display for FmtAlternative {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        encode_alternative_fmt(self.0.clone(), f)
+        encode_alternative_fmt(self.0, f)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,15 +56,15 @@ pub enum EncodeError {
     BufferTooSmall,
 }
 
-impl core::fmt::Display for DecodeError {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+impl fmt::Display for DecodeError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             DecodeError::ArithmeticOverflow => {
                 f.write_str("Decoded number cannot fit into a `u128`")
             }
             DecodeError::EmptyInput => f.write_str("Encoded input is an empty string"),
             DecodeError::InvalidBase62Byte(ch, idx) => {
-                use core::fmt::Write;
+                use fmt::Write;
                 f.write_str("Encoded input contains the invalid byte b'")?;
                 for char_in_escape in core::ascii::escape_default(ch) {
                     f.write_char(char::from(char_in_escape))?;
@@ -92,8 +92,8 @@ impl core::error::Error for EncodeError {}
 impl std::error::Error for EncodeError {}
 
 // You'll also need to implement std::fmt::Display for EncodeError since it's required for Error
-impl core::fmt::Display for EncodeError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+impl fmt::Display for EncodeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             EncodeError::BufferTooSmall => write!(f, "Buffer too small to encode the number"),
         }
@@ -104,7 +104,6 @@ impl core::fmt::Display for EncodeError {
 ///
 /// # Example
 /// ```rust
-/// # use core::fmt::Write;
 /// let mut output = String::new();
 /// base62::encode_fmt(1337_u32, &mut output).unwrap();
 /// assert_eq!(output, "LZ");
@@ -125,12 +124,24 @@ pub fn encode_fmt<T: Into<u128>, W: fmt::Write + ?Sized>(num: T, f: &mut W) -> f
     }
 }
 
+/// Transparent wrapper over a value, [`Display`]ing it via [`encode_fmt()`].
+///
+/// [`Display`]: fmt::Display
+#[derive(Copy, Clone, Debug)]
+#[repr(transparent)]
+pub struct Display<T>(pub T);
+
+impl<T: Clone + Into<u128>> fmt::Display for Display<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        encode_fmt(self.0.clone(), f)
+    }
+}
+
 /// Writes the base62 representation of a number using the alternative alphabet (0 to 9, then a to z, then A to Z)
 /// to any fmt::Write destination.
 ///
 /// # Example
 /// ```rust
-/// # use core::fmt::Write;
 /// let mut output = String::new();
 /// base62::encode_alternative_fmt(1337_u32, &mut output).unwrap();
 /// assert_eq!(output, "lz");
@@ -151,6 +162,19 @@ pub fn encode_alternative_fmt<T: Into<u128>, W: fmt::Write + ?Sized>(
             f.write_char(char::from_u32_unchecked(b as u32))?;
         }
         Ok(())
+    }
+}
+
+/// Transparent wrapper over a value, [`Display`]ing it via [`encode_alternative_fmt()`].
+///
+/// [`Display`]: fmt::Display
+#[derive(Copy, Clone, Debug)]
+#[repr(transparent)]
+pub struct DisplayAlternative<T>(pub T);
+
+impl<T: Clone + Into<u128>> fmt::Display for Display<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        encode_alternative_fmt(self.0.clone(), f)
     }
 }
 


### PR DESCRIPTION
Follows #16, #17


## Motivation

Applying the `base62::encode_fmt()` in my codebases, I've found that it doesn't play smooth with macro-based or non-transparent APIs (like `derive_more::Display` or `thiserror::Error`).

Consider the code before applying #17:
```rust
#[derive(derive_more::Display)]
#[display("{:0>22}", base62::encode(*_0))]
pub struct Version(u128);
```

This code now should be written "by hand", since `base62::encode()` cannot be substituted with `base62::encode_fmt()` trivially here.


## Solution

This PR introduces two functions: `base62::fmt()` and `base62::fmt_alt()`. They allow applying `base62` encoding easily in any `format!()`-like expressions, still avoiding unnecessary allocations.

```rust
#[derive(derive_more::Display)]
#[display("{:0>22}", base62::fmt(*_0))]
pub struct Version(u128);
```