### PR TITLE
upgrade rand to 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ std = ["alloc"]
 [dev-dependencies]
 criterion = { version = "0.7", default-features = false }
 quickcheck = "1"
-rand = "0.9"
+rand = "0.10"
 
 [[bench]]
 name = "base62"


### PR DESCRIPTION
based on: https://salsa.debian.org/rust-team/debcargo-conf/-/blob/master/src/base62/debian/patches/disable-benches.patch?ref_type=heads#L34